### PR TITLE
Allow execution of queue.sh from anywhere

### DIFF
--- a/epic-hacks/queue.sh
+++ b/epic-hacks/queue.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-kubectl create -f <(TRACK="$*" envsubst <./job.tmpl.yaml)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+kubectl create -f <(TRACK="$*" envsubst < "$DIR/job.tmpl.yaml")


### PR DESCRIPTION
Discover the current dir, and use job template from there