### PR TITLE
Human friendly job names

### DIFF
--- a/epic-hacks/job.tmpl.yaml
+++ b/epic-hacks/job.tmpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: track-
+  generateName: track-$JOB_NAME-
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 10

--- a/epic-hacks/queue.sh
+++ b/epic-hacks/queue.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-kubectl create -f <(TRACK="$*" envsubst <./job.tmpl.yaml)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+kubectl create -f <(TRACK="$*" envsubst < "$DIR/job.tmpl.yaml")

--- a/epic-hacks/queue.sh
+++ b/epic-hacks/queue.sh
@@ -3,4 +3,13 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-kubectl create -f <(TRACK="$*" envsubst < "$DIR/job.tmpl.yaml")
+TRACK="$*"
+
+# Create a Kubernetes friendly name of the track search input
+JOB_NAME=${TRACK// /-} # remove spaces from $TRACK
+JOB_NAME=${JOB_NAME//:/-} # replace : with -
+JOB_NAME=$(echo "$JOB_NAME" | tr [:upper:] [:lower:]) # lowercase
+JOB_NAME=$(echo "$JOB_NAME" | LANG=c tr -cd '[:print:]') # remove non ascii characters
+JOB_NAME=$(echo "$JOB_NAME" | cut -c-253) # trim to max 253 characters
+
+kubectl create -f <(TRACK="$TRACK" JOB_NAME="$JOB_NAME" envsubst < "$DIR/job.tmpl.yaml")


### PR DESCRIPTION
This is based on top of #1 

---

```
$ ./queue.sh "Satan i gatan"
job.batch/track-satan-i-gatan-gfbfv created
```

```
# kubectl get pods -owide --watch
track-satan-i-gatan-gfbfv-bf6n8    0/1     Pending             0          0s      <none>      dj-control-plane   <none>           <none>
track-satan-i-gatan-gfbfv-bf6n8    0/1     ContainerCreating   0          0s      <none>      dj-control-plane   <none>           <none>
track-satan-i-gatan-gfbfv-bf6n8    1/1     Running             0          1s      10.32.0.4   dj-control-plane   <none>           <none>
track-satan-i-gatan-gfbfv-bf6n8    0/1     Completed           0          3m23s   10.32.0.4   dj-control-plane   <none>           <none>
```